### PR TITLE
trigger.create should not include empty ValueType

### DIFF
--- a/zabbixprovisioner/zabbixclient/trigger.go
+++ b/zabbixprovisioner/zabbixclient/trigger.go
@@ -31,7 +31,7 @@ type Trigger struct {
 	Comments    string       `json:"comments"`
 	URL         string       `json:"url"`
 	ManualClose int32        `json:"manual_close"`
-	Value       ValueType    `json:""`
+	Value       ValueType    `json:",omitempty"`
 	Priority    PriorityType `json:"priority"`
 	Status      StatusType   `json:"status"`
 	Tags        []Tag        `json:"tags"`


### PR DESCRIPTION
Hello,

I have had a problem with zal prov which this fixes. My environment is using Zabbix 5.2.

When running zal_prov, the trigger creation was failing for me. The reason was that zal prov was giving an empty value for the Value property when calling trigger.create.
As per zabbix documentation value is readonly and should not be provided when calling trigger.create.

I have added omitempty in the Trigger object definition so that ValueType is not included in trigger.create when its value is empty.
This has allowed me to complete provisionning of my alerts in zabbix.
This change has had no effect of other api calls for me or when sending data into zabbix.